### PR TITLE
Update sidebar to afford expanding and collapsing sections

### DIFF
--- a/ui/src/app/+admin/admin.component.ts
+++ b/ui/src/app/+admin/admin.component.ts
@@ -44,10 +44,10 @@ export class AdminComponent implements OnInit {
                                 route: ['/admin/users'],
                             }
                         ],
-                        collapsable: { allowed: false }
+                        collapsible: { allowed: false }
                     }
                 ],
-                collapsable: { allowed: true }
+                collapsible: { allowed: true }
             }
         }));
     }

--- a/ui/src/app/+admin/admin.component.ts
+++ b/ui/src/app/+admin/admin.component.ts
@@ -44,10 +44,10 @@ export class AdminComponent implements OnInit {
                                 route: ['/admin/users'],
                             }
                         ],
-                        collapsible: false
+                        collapsable: { allowed: false }
                     }
                 ],
-                collapsible: true
+                collapsable: { allowed: true }
             }
         }));
     }

--- a/ui/src/app/core/model/sidebar/sidebar-menu.ts
+++ b/ui/src/app/core/model/sidebar/sidebar-menu.ts
@@ -1,8 +1,8 @@
 import { SidebarSection } from './';
-import { Collapsable } from '../theme/collapsable';
+import { Collapsible } from '../theme/collapsible';
 
 export interface SidebarMenu {
     sections: SidebarSection[];
-    collapsable: Collapsable;
+    collapsible: Collapsible;
     classes?: string;
 }

--- a/ui/src/app/core/model/sidebar/sidebar-menu.ts
+++ b/ui/src/app/core/model/sidebar/sidebar-menu.ts
@@ -1,7 +1,8 @@
 import { SidebarSection } from './';
+import { Collapsable } from '../theme/collapsable';
 
 export interface SidebarMenu {
     sections: SidebarSection[];
-    collapsible: boolean;
+    collapsable: Collapsable;
     classes?: string;
 }

--- a/ui/src/app/core/model/sidebar/sidebar-section.ts
+++ b/ui/src/app/core/model/sidebar/sidebar-section.ts
@@ -1,9 +1,10 @@
 import { Observable } from 'rxjs';
 import { SidebarItem } from './';
+import { Collapsable } from '../theme/collapsable';
 
 export interface SidebarSection {
     title: Observable<string>;
     items: SidebarItem[];
-    collapsible: boolean;
+    collapsable: Collapsable;
     classes?: string;
 }

--- a/ui/src/app/core/model/sidebar/sidebar-section.ts
+++ b/ui/src/app/core/model/sidebar/sidebar-section.ts
@@ -1,10 +1,10 @@
 import { Observable } from 'rxjs';
 import { SidebarItem } from './';
-import { Collapsable } from '../theme/collapsable';
+import { Collapsible } from '../theme/collapsible';
 
 export interface SidebarSection {
     title: Observable<string>;
     items: SidebarItem[];
-    collapsable: Collapsable;
+    collapsible: Collapsible;
     classes?: string;
 }

--- a/ui/src/app/core/model/theme/collapsable.ts
+++ b/ui/src/app/core/model/theme/collapsable.ts
@@ -1,0 +1,4 @@
+export interface Collapsable {
+    readonly allowed: boolean;
+    readonly collapsed?: boolean;
+}

--- a/ui/src/app/core/model/theme/collapsible.ts
+++ b/ui/src/app/core/model/theme/collapsible.ts
@@ -1,4 +1,4 @@
-export interface Collapsable {
+export interface Collapsible {
     readonly allowed: boolean;
     readonly collapsed?: boolean;
 }

--- a/ui/src/app/core/store/sidebar/sidebar.actions.ts
+++ b/ui/src/app/core/store/sidebar/sidebar.actions.ts
@@ -3,7 +3,13 @@ import { SidebarMenu } from '../../model/sidebar';
 
 export enum SidebarActionTypes {
     LOAD_SIDEBAR = '[Sidebar] load',
-    UNLOAD_SIDEBAR = '[Sidebar] unload'
+    UNLOAD_SIDEBAR = '[Sidebar] unload',
+    TOGGLE_COLLAPSABLE_SECTION = '[Sidebar] toggle collapsable section'
+}
+
+export class ToggleCollapsableSectionAction implements Action {
+    readonly type = SidebarActionTypes.TOGGLE_COLLAPSABLE_SECTION;
+    constructor(public payload: { sectionIndex: number }) { }
 }
 
 export class LoadSidebarAction implements Action {
@@ -16,5 +22,6 @@ export class UnloadSidebarAction implements Action {
 }
 
 export type SidebarActions =
+    ToggleCollapsableSectionAction |
     LoadSidebarAction |
     UnloadSidebarAction;

--- a/ui/src/app/core/store/sidebar/sidebar.actions.ts
+++ b/ui/src/app/core/store/sidebar/sidebar.actions.ts
@@ -4,11 +4,11 @@ import { SidebarMenu } from '../../model/sidebar';
 export enum SidebarActionTypes {
     LOAD_SIDEBAR = '[Sidebar] load',
     UNLOAD_SIDEBAR = '[Sidebar] unload',
-    TOGGLE_COLLAPSABLE_SECTION = '[Sidebar] toggle collapsable section'
+    TOGGLE_COLLAPSIBLE_SECTION = '[Sidebar] toggle collapsible section'
 }
 
-export class ToggleCollapsableSectionAction implements Action {
-    readonly type = SidebarActionTypes.TOGGLE_COLLAPSABLE_SECTION;
+export class ToggleCollapsibleSectionAction implements Action {
+    readonly type = SidebarActionTypes.TOGGLE_COLLAPSIBLE_SECTION;
     constructor(public payload: { sectionIndex: number }) { }
 }
 
@@ -22,6 +22,6 @@ export class UnloadSidebarAction implements Action {
 }
 
 export type SidebarActions =
-    ToggleCollapsableSectionAction |
+    ToggleCollapsibleSectionAction |
     LoadSidebarAction |
     UnloadSidebarAction;

--- a/ui/src/app/core/store/sidebar/sidebar.reducer.ts
+++ b/ui/src/app/core/store/sidebar/sidebar.reducer.ts
@@ -11,6 +11,14 @@ export const initialState: SidebarState = {
 
 export function reducer(state = initialState, action: SidebarActions): SidebarState {
     switch (action.type) {
+        case SidebarActionTypes.TOGGLE_COLLAPSABLE_SECTION:
+            const newState = {...state};
+            const collapsable = newState.menu.sections[action.payload.sectionIndex].collapsable;
+            newState.menu.sections[action.payload.sectionIndex].collapsable = {
+                allowed: collapsable.allowed,
+                collapsed: !collapsable.collapsed
+            };
+            return newState;
         case SidebarActionTypes.LOAD_SIDEBAR:
             return {
                 ...state,

--- a/ui/src/app/core/store/sidebar/sidebar.reducer.ts
+++ b/ui/src/app/core/store/sidebar/sidebar.reducer.ts
@@ -11,12 +11,12 @@ export const initialState: SidebarState = {
 
 export function reducer(state = initialState, action: SidebarActions): SidebarState {
     switch (action.type) {
-        case SidebarActionTypes.TOGGLE_COLLAPSABLE_SECTION:
+        case SidebarActionTypes.TOGGLE_COLLAPSIBLE_SECTION:
             const newState = {...state};
-            const collapsable = newState.menu.sections[action.payload.sectionIndex].collapsable;
-            newState.menu.sections[action.payload.sectionIndex].collapsable = {
-                allowed: collapsable.allowed,
-                collapsed: !collapsable.collapsed
+            const collapsible = newState.menu.sections[action.payload.sectionIndex].collapsible;
+            newState.menu.sections[action.payload.sectionIndex].collapsible = {
+                allowed: collapsible.allowed,
+                collapsed: !collapsible.collapsed
             };
             return newState;
         case SidebarActionTypes.LOAD_SIDEBAR:

--- a/ui/src/app/shared/sidebar/sidebar.component.html
+++ b/ui/src/app/shared/sidebar/sidebar.component.html
@@ -1,10 +1,10 @@
 <div class="wrapper container">
     <nav class="sidebar {{menu.classes}}" *ngIf="menu | async; let menu">
-        <div class="card bg-dark" *ngFor="let section of menu.sections">
-            <div class="card-header text-white {{section.classes}}">
+        <div class="card bg-dark" *ngFor="let section of menu.sections; let sectionIndex = index">
+            <div class="card-header text-white {{section.classes}}" (click)="toggleSectionCollapse(sectionIndex)">
                 <span class="header-title">{{section.title | async}}</span>
             </div>
-            <ul class="list-group list-group-flush" *ngFor="let item of section.items">
+            <ul class="list-group list-group-flush" *ngFor="let item of section.items" [ngbCollapse]="isSectionCollapsed(section.collapsable)">
                 <li class="list-group-item list-group-item-action list-group-item-light link {{item.classes}}" [routerLink]="item.route" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact: false}" aria-role="link" [attr.aria-label]="'SHARED.SIDEBAR.LINK.ARIA_LABEL' | translate">
                     <label class="item-label" *ngIf="item.checkbox"><input class="item-checkbox" type="checkbox" [checked]="item.checked"> {{item.label | async}}</label>
                     <span class="item-label" *ngIf="!item.checkbox">{{item.label | async}}</span>

--- a/ui/src/app/shared/sidebar/sidebar.component.html
+++ b/ui/src/app/shared/sidebar/sidebar.component.html
@@ -5,17 +5,19 @@
                 <span class="header-title">{{section.title | async}}</span>
                 <span class="header-collapsible fa {{getSectionCollapsibleIcon(section.collapsible)}}" (click)="toggleSectionCollapse(sectionIndex)" *ngIf="isSectionCollapsible(section.collapsible)" aria-role="button" [attr.aria-label]="translateSectionCollapsibleButton(section.collapsible, section.title | async) | async"></span>
             </div>
-            <ul class="list-group list-group-flush" *ngFor="let item of section.items" [ngbCollapse]="isSectionCollapsed(section.collapsible)">
-                <li class="list-group-item list-group-item-action list-group-item-light link {{item.classes}}" [routerLink]="item.route" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact: false}" aria-role="link" [attr.aria-label]="'SHARED.SIDEBAR.LINK.ARIA_LABEL' | translate">
-                    <label class="item-label" *ngIf="item.checkbox"><input class="item-checkbox" type="checkbox" [checked]="item.checked"> {{item.label | async}}</label>
-                    <span class="item-label" *ngIf="!item.checkbox">{{item.label | async}}</span>
-                    <span class="item-total" *ngIf="item.total"> ({{item.total | async}})</span>
-                    <span class="item-fields" *ngFor="let field of item.fields">
-                        <label class="field-label {{field.label.classes}}" [for]="field.label.for">{{field.label.value}}</label>
-                        <input class="field-input {{field.input.classes}}" [id]="field.input.id" [name]="field.input.name" [type]="field.input.type" [placeholder]="field.input.placeholder" [value]="field.input.value" [checked]="field.input.checked">
-                    </span>
-                </li>
-            </ul>
+            <div class="card-items" [ngbCollapse]="isSectionCollapsed(section.collapsible)">
+                <ul class="list-group list-group-flush" *ngFor="let item of section.items">
+                    <li class="list-group-item list-group-item-action list-group-item-light link {{item.classes}}" [routerLink]="item.route" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact: false}" aria-role="link" [attr.aria-label]="'SHARED.SIDEBAR.LINK.ARIA_LABEL' | translate">
+                        <label class="item-label" *ngIf="item.checkbox"><input class="item-checkbox" type="checkbox" [checked]="item.checked"> {{item.label | async}}</label>
+                        <span class="item-label" *ngIf="!item.checkbox">{{item.label | async}}</span>
+                        <span class="item-total" *ngIf="item.total"> ({{item.total | async}})</span>
+                        <span class="item-fields" *ngFor="let field of item.fields">
+                            <label class="field-label {{field.label.classes}}" [for]="field.label.for">{{field.label.value}}</label>
+                            <input class="field-input {{field.input.classes}}" [id]="field.input.id" [name]="field.input.name" [type]="field.input.type" [placeholder]="field.input.placeholder" [value]="field.input.value" [checked]="field.input.checked">
+                        </span>
+                    </li>
+                </ul>
+            </div>
         </div>
     </nav>
     <div class="content container">

--- a/ui/src/app/shared/sidebar/sidebar.component.html
+++ b/ui/src/app/shared/sidebar/sidebar.component.html
@@ -1,8 +1,9 @@
 <div class="wrapper container">
     <nav class="sidebar {{menu.classes}}" *ngIf="menu | async; let menu">
         <div class="card bg-dark" *ngFor="let section of menu.sections; let sectionIndex = index">
-            <div class="card-header text-white {{section.classes}}" (click)="toggleSectionCollapse(sectionIndex)">
+            <div class="card-header text-white {{section.classes}}">
                 <span class="header-title">{{section.title | async}}</span>
+                <span class="header-collapsable fa {{getSectionCollapsableIcon(section.collapsable)}}" (click)="toggleSectionCollapse(sectionIndex)" *ngIf="isSectionCollapsable(section.collapsable)" aria-role="button" [attr.aria-label]="translateSectionCollapsableButton(section.collapsable, section.title | async) | async"></span>
             </div>
             <ul class="list-group list-group-flush" *ngFor="let item of section.items" [ngbCollapse]="isSectionCollapsed(section.collapsable)">
                 <li class="list-group-item list-group-item-action list-group-item-light link {{item.classes}}" [routerLink]="item.route" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact: false}" aria-role="link" [attr.aria-label]="'SHARED.SIDEBAR.LINK.ARIA_LABEL' | translate">

--- a/ui/src/app/shared/sidebar/sidebar.component.html
+++ b/ui/src/app/shared/sidebar/sidebar.component.html
@@ -3,9 +3,9 @@
         <div class="card bg-dark" *ngFor="let section of menu.sections; let sectionIndex = index">
             <div class="card-header text-white {{section.classes}}">
                 <span class="header-title">{{section.title | async}}</span>
-                <span class="header-collapsable fa {{getSectionCollapsableIcon(section.collapsable)}}" (click)="toggleSectionCollapse(sectionIndex)" *ngIf="isSectionCollapsable(section.collapsable)" aria-role="button" [attr.aria-label]="translateSectionCollapsableButton(section.collapsable, section.title | async) | async"></span>
+                <span class="header-collapsible fa {{getSectionCollapsibleIcon(section.collapsible)}}" (click)="toggleSectionCollapse(sectionIndex)" *ngIf="isSectionCollapsible(section.collapsible)" aria-role="button" [attr.aria-label]="translateSectionCollapsibleButton(section.collapsible, section.title | async) | async"></span>
             </div>
-            <ul class="list-group list-group-flush" *ngFor="let item of section.items" [ngbCollapse]="isSectionCollapsed(section.collapsable)">
+            <ul class="list-group list-group-flush" *ngFor="let item of section.items" [ngbCollapse]="isSectionCollapsed(section.collapsible)">
                 <li class="list-group-item list-group-item-action list-group-item-light link {{item.classes}}" [routerLink]="item.route" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact: false}" aria-role="link" [attr.aria-label]="'SHARED.SIDEBAR.LINK.ARIA_LABEL' | translate">
                     <label class="item-label" *ngIf="item.checkbox"><input class="item-checkbox" type="checkbox" [checked]="item.checked"> {{item.label | async}}</label>
                     <span class="item-label" *ngIf="!item.checkbox">{{item.label | async}}</span>

--- a/ui/src/app/shared/sidebar/sidebar.component.scss
+++ b/ui/src/app/shared/sidebar/sidebar.component.scss
@@ -12,7 +12,7 @@
         .card-header {
           font-weight: bold;
 
-          .header-collapsable {
+          .header-collapsible {
             float: right;
             font-size: 1.3em;
             line-height: 1.1em;

--- a/ui/src/app/shared/sidebar/sidebar.component.scss
+++ b/ui/src/app/shared/sidebar/sidebar.component.scss
@@ -9,6 +9,8 @@
       max-width: 250px;
 
       .card {
+        margin-bottom: 10px;
+
         .card-header {
           font-weight: bold;
 

--- a/ui/src/app/shared/sidebar/sidebar.component.scss
+++ b/ui/src/app/shared/sidebar/sidebar.component.scss
@@ -11,6 +11,12 @@
       .card {
         .card-header {
           font-weight: bold;
+
+          .header-collapsable {
+            float: right;
+            font-size: 1.3em;
+            line-height: 1.1em;
+          }
         }
       }
     }
@@ -19,6 +25,5 @@
       margin-left: 0px;
     }
 
-    
   }
 }

--- a/ui/src/app/shared/sidebar/sidebar.component.spec.ts
+++ b/ui/src/app/shared/sidebar/sidebar.component.spec.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 import { StoreModule } from '@ngrx/store';
 
 import { SharedModule } from '../shared.module';
@@ -20,6 +21,7 @@ describe('SidebarComponent', () => {
                 StoreModule.forRoot(reducers, {
                     metaReducers
                 }),
+                TranslateModule.forRoot(),
                 RouterTestingModule.withRoutes([])
             ],
             schemas: [

--- a/ui/src/app/shared/sidebar/sidebar.component.ts
+++ b/ui/src/app/shared/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
+import { TranslateService } from '@ngx-translate/core';
 
 import { Observable } from 'rxjs';
 
@@ -21,15 +22,37 @@ export class SidebarComponent implements OnInit {
 
     public menu: Observable<SidebarMenu>;
 
-    constructor(private store: Store<AppState>) {
+    constructor(private store: Store<AppState>, private translate: TranslateService) {
     }
 
     ngOnInit() {
         this.menu = this.store.pipe(select(selectMenu));
     }
 
+    public getSectionCollapsableIcon(collapsable: Collapsable): string {
+        if (this.isSectionCollapsable(collapsable)) {
+            return this.isSectionCollapsed(collapsable) ? 'fa-caret-right' : 'fa-caret-down';
+        }
+
+        return '';
+    }
+
     public toggleSectionCollapse(sectionIndex: number): void {
         this.store.dispatch(new fromSidebar.ToggleCollapsableSectionAction({sectionIndex}));
+    }
+
+    public translateSectionCollapsableButton(collapsable: Collapsable, label: string): Observable<string> {
+        let key = 'SHARED.SIDEBAR.SECTION.ARIA_LABEL_COLLAPSE';
+
+        if (this.isSectionCollapsed(collapsable)) {
+            key = 'SHARED.SIDEBAR.SECTION.ARIA_LABEL_EXPAND';
+        }
+
+        return this.translate.get(key, { label });
+    }
+
+    public isSectionCollapsable(collapsable: Collapsable): boolean {
+        return collapsable.allowed;
     }
 
     public isSectionCollapsed(collapsable: Collapsable): boolean {

--- a/ui/src/app/shared/sidebar/sidebar.component.ts
+++ b/ui/src/app/shared/sidebar/sidebar.component.ts
@@ -5,11 +5,12 @@ import { Observable } from 'rxjs';
 
 import { AppState } from '../../core/store';
 import { SidebarMenu } from '../../core/model/sidebar';
+import { Collapsable } from '../../core/model/theme/collapsable';
 
 import { selectIsSidebarCollapsed } from '../../core/store/layout';
 import { selectMenu } from '../../core/store/sidebar';
 
-import * as fromLayout from '../../core/store/layout/layout.actions';
+import * as fromSidebar from '../../core/store/sidebar/sidebar.actions';
 
 @Component({
     selector: 'scholars-sidebar',
@@ -20,19 +21,19 @@ export class SidebarComponent implements OnInit {
 
     public menu: Observable<SidebarMenu>;
 
-    public isSidebarCollapsed: Observable<boolean>;
-
     constructor(private store: Store<AppState>) {
-
     }
 
     ngOnInit() {
         this.menu = this.store.pipe(select(selectMenu));
-        this.isSidebarCollapsed = this.store.pipe(select(selectIsSidebarCollapsed));
     }
 
-    public toggleSidebar(): void {
-        this.store.dispatch(new fromLayout.ToggleSidebarAction());
+    public toggleSectionCollapse(sectionIndex: number): void {
+        this.store.dispatch(new fromSidebar.ToggleCollapsableSectionAction({sectionIndex}));
+    }
+
+    public isSectionCollapsed(collapsable: Collapsable): boolean {
+        return collapsable.allowed && collapsable.collapsed;
     }
 
 }

--- a/ui/src/app/shared/sidebar/sidebar.component.ts
+++ b/ui/src/app/shared/sidebar/sidebar.component.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 
 import { AppState } from '../../core/store';
 import { SidebarMenu } from '../../core/model/sidebar';
-import { Collapsable } from '../../core/model/theme/collapsable';
+import { Collapsible } from '../../core/model/theme/collapsible';
 
 import { selectIsSidebarCollapsed } from '../../core/store/layout';
 import { selectMenu } from '../../core/store/sidebar';
@@ -29,34 +29,34 @@ export class SidebarComponent implements OnInit {
         this.menu = this.store.pipe(select(selectMenu));
     }
 
-    public getSectionCollapsableIcon(collapsable: Collapsable): string {
-        if (this.isSectionCollapsable(collapsable)) {
-            return this.isSectionCollapsed(collapsable) ? 'fa-caret-right' : 'fa-caret-down';
+    public getSectionCollapsibleIcon(collapsible: Collapsible): string {
+        if (this.isSectionCollapsible(collapsible)) {
+            return this.isSectionCollapsed(collapsible) ? 'fa-caret-right' : 'fa-caret-down';
         }
 
         return '';
     }
 
     public toggleSectionCollapse(sectionIndex: number): void {
-        this.store.dispatch(new fromSidebar.ToggleCollapsableSectionAction({sectionIndex}));
+        this.store.dispatch(new fromSidebar.ToggleCollapsibleSectionAction({sectionIndex}));
     }
 
-    public translateSectionCollapsableButton(collapsable: Collapsable, label: string): Observable<string> {
+    public translateSectionCollapsibleButton(collapsible: Collapsible, label: string): Observable<string> {
         let key = 'SHARED.SIDEBAR.SECTION.ARIA_LABEL_COLLAPSE';
 
-        if (this.isSectionCollapsed(collapsable)) {
+        if (this.isSectionCollapsed(collapsible)) {
             key = 'SHARED.SIDEBAR.SECTION.ARIA_LABEL_EXPAND';
         }
 
         return this.translate.get(key, { label });
     }
 
-    public isSectionCollapsable(collapsable: Collapsable): boolean {
-        return collapsable.allowed;
+    public isSectionCollapsible(collapsible: Collapsible): boolean {
+        return collapsible.allowed;
     }
 
-    public isSectionCollapsed(collapsable: Collapsable): boolean {
-        return collapsable.allowed && collapsable.collapsed;
+    public isSectionCollapsed(collapsible: Collapsible): boolean {
+        return collapsible.allowed && collapsible.collapsed;
     }
 
 }

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -115,6 +115,10 @@
       },
       "LINK": {
         "ARIA_LABEL": "Navigation link."
+      },
+      "SECTION": {
+          "ARIA_LABEL_COLLAPSE": "Collapse the {{label}} section.",
+          "ARIA_LABEL_EXPAND": "Expand the {{label}} section."
       }
     },
     "ALERT": {


### PR DESCRIPTION
This creates and utilizes a `Collapsable` to store both allowing/denying collapsable as well as the state of being collapsed.

It is currently unclear to me whether `collapsable` needs to exist on the menu itself but given that this PR adds `Collapsable` the menu `collapsable` has been updated to be a `Collapsable`.
The preexisting `isSidebarCollapsed` code has been removed.

This uses the array index to toggle the collapsable state, but I am open to using a unique identifier such as through a map.